### PR TITLE
Async connect for android + Simulator calls unblock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,7 @@ buck-out/
 # Bundle artifact
 *.jsbundle
 index.android.bundle
+
+*.project
+
+*.settings/

--- a/android/src/main/java/com/tadasr/IOTWifi/IOTWifiModule.java
+++ b/android/src/main/java/com/tadasr/IOTWifi/IOTWifiModule.java
@@ -50,6 +50,10 @@ public class IOTWifiModule extends ReactContextBaseJavaModule {
     }
 
     private void connectToWifi(String ssid, String passphrase, Boolean isWEP, Callback callback) {
+        if (Build.VERSION.SDK_INT > 28) {
+            callback.invoke("Fail");
+            return;
+        }
         WifiConfiguration configuration = new WifiConfiguration();
         configuration.SSID = String.format("\"%s\"", ssid);
 

--- a/ios/IOTWifi.m
+++ b/ios/IOTWifi.m
@@ -1,25 +1,18 @@
 #import "IOTWifi.h"
-#if !TARGET_OS_SIMULATOR
 #import <NetworkExtension/NetworkExtension.h>
-#endif
 #import <SystemConfiguration/CaptiveNetwork.h>
 
 
 @implementation IOTWifi
     RCT_EXPORT_MODULE();
     RCT_EXPORT_METHOD(isAvaliable:(RCTResponseSenderBlock)callback) {
-#if TARGET_OS_SIMULATOR
-        callback(@[@NO]);
-#else
         NSNumber *available = @NO;
         if (@available(iOS 11.0, *)) {
             available = @YES;
         }
         callback(@[available]);
-#endif
     }
     
-#if !TARGET_OS_SIMULATOR
     RCT_EXPORT_METHOD(connect:(NSString*)ssid
                       callback:(RCTResponseSenderBlock)callback) {
         if (@available(iOS 11.0, *)) {
@@ -108,7 +101,5 @@
                       rejecter:(RCTPromiseRejectBlock)reject) {
         reject(@"no_implementation", @"There are no implementation on iOS", [NSError errorWithDomain:@"com.iotwifi" code:-1 userInfo:nil]);
     }
-    
-#endif
-    @end
+@end
 


### PR DESCRIPTION
This PR has some changes for a better dev experience on both iOS and android.
Android:
- Makes the connect call asynchronous and non blocking but doing the work in a thread instead of the called thread.
- Fails for Android Q as the API is deprecated (support for Android Q https://developer.android.com/reference/android/net/wifi/WifiNetworkSpecifier.Builder.html)

iOS:
- APIs were unsuable on Simulator as it was behind a compile time macro
- Exposed and returns defaults for sim targets.
