### PR TITLE
Allow android Q to use wifi api for now

### DIFF
--- a/android/src/main/java/com/tadasr/IOTWifi/IOTWifiModule.java
+++ b/android/src/main/java/com/tadasr/IOTWifi/IOTWifiModule.java
@@ -68,10 +68,6 @@ public class IOTWifiModule extends ReactContextBaseJavaModule {
     }
 
     private void connectToWifi(String ssid, String passphrase, Boolean isWEP, Boolean bindNetwork, Callback callback) {
-        if (Build.VERSION.SDK_INT > 28) {
-            callback.invoke("Not supported on Android Q");
-            return;
-        }
         if (!removeSSID(ssid)) {
             callback.invoke(errorFromCode(FailureCodes.SYSTEM_ADDED_CONFIG_EXISTS));
             return;


### PR DESCRIPTION
After a bit more testing turns out Android Q is still supporting the old API and rejecting the wifi connect calls for it makes less sense.
This PR will open up the connect API to be used by Android Q again.
