### PR TITLE
Add podspec to support iOS auto-linking in RN >=0.60

### DIFF
--- a/ios/react-native-iot-wifi.podspec
+++ b/ios/react-native-iot-wifi.podspec
@@ -1,0 +1,17 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, '../package.json')))
+
+Pod::Spec.new do |s|
+  s.name         = package['name']
+  s.version      = package['version']
+  s.summary      = package['description']
+  s.license      = package['license']
+
+  s.authors      = package['authors']
+  s.homepage     = package['homepage']
+  s.platform     = :ios, "9.0"
+
+  s.source       = { :git => "https://github.com/tadasr/react-native-iot-wifi.git", :tag => "#{s.version}" }
+  s.source_files  = "ios/**/*.{h,m}"
+end


### PR DESCRIPTION
Adding the podspec and `pod 'react-native-iot-wifi', :podspec => '../node_modules/react-native-iot-wifi/ios/react-native-iot-wifi.podspec'` will allow those using this on React Native >=0.60 to auto-link.