### PR TITLE
TCIL-CWT-3141: Add support for React Native versions  >= 0.60

### DIFF
--- a/IOTWifi.podspec
+++ b/IOTWifi.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.description         = package['description']
   s.homepage            = package['homepage']
   s.license             = package['license']
-  s.author              = package['author']
+  s.author              = package['authors_0']
   s.source              = { :git => 'https://github.com/tadasr/react-native-iot-wifi.git' }
   s.platform              = :ios, '10.3'
   s.ios.deployment_target = '10.3'

--- a/IOTWifi.podspec
+++ b/IOTWifi.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.description         = package['description']
   s.homepage            = package['homepage']
   s.license             = package['license']
-  s.author              = package['authors_0']
+  s.author              = package['author']
   s.source              = { :git => 'https://github.com/tadasr/react-native-iot-wifi.git' }
   s.platform              = :ios, '10.3'
   s.ios.deployment_target = '10.3'

--- a/IOTWifi.podspec
+++ b/IOTWifi.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.homepage            = package['homepage']
   s.license             = package['license']
   s.author              = package['author']
-  s.source              = { :git => 'https://github.com/hudl/react-native-iot-wifi.git' }
+  s.source              = { :git => 'https://github.com/tadasr/react-native-iot-wifi.git' }
   s.platform              = :ios, '10.3'
   s.ios.deployment_target = '10.3'
   s.source_files        = 'ios/**/*.{h,m}'

--- a/IOTWifi.podspec
+++ b/IOTWifi.podspec
@@ -1,0 +1,21 @@
+require 'json'
+
+package = JSON.parse(File.read('package.json'))
+
+Pod::Spec.new do |s|
+  s.name                = 'IOTWifi'
+  s.version             = package['version']
+  s.summary             = package['description']
+  s.description         = package['description']
+  s.homepage            = package['homepage']
+  s.license             = package['license']
+  s.author              = package['author']
+  s.source              = { :git => 'https://github.com/hudl/react-native-iot-wifi.git' }
+  s.platform              = :ios, '10.3'
+  s.ios.deployment_target = '10.3'
+  s.source_files        = 'ios/**/*.{h,m}'
+  s.exclude_files       = 'android/**/*'
+  s.exclude_files       = 'example/**/*'
+  s.dependency 'React'
+end 
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-iot-wifi",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Connect to WiFi with React Native on Android and iOS.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -23,9 +23,7 @@
     "wifi",
     "iot"
   ],
-  "authors": [
-    "tadasr"
-  ],
+  "author": "tadasr",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/tadasr/react-native-iot-wifi/issues"


### PR DESCRIPTION
This PR adds a .podspec file to the root of the repo and bumps the package by a minor version.