### PR TITLE
Add podspec to support autolinking in React Native version >= 0.60

### DIFF
--- a/IOTWifi.podspec
+++ b/IOTWifi.podspec
@@ -1,0 +1,21 @@
+require 'json'
+
+package = JSON.parse(File.read('package.json'))
+
+Pod::Spec.new do |s|
+  s.name                = 'IOTWifi'
+  s.version             = package['version']
+  s.summary             = package['description']
+  s.description         = package['description']
+  s.homepage            = package['homepage']
+  s.license             = package['license']
+  s.author              = package['author']
+  s.source              = { :git => 'https://github.com/tadasr/react-native-iot-wifi.git' }
+  s.platform              = :ios, '10.3'
+  s.ios.deployment_target = '10.3'
+  s.source_files        = 'ios/**/*.{h,m}'
+  s.exclude_files       = 'android/**/*'
+  s.exclude_files       = 'example/**/*'
+  s.dependency 'React'
+end 
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-iot-wifi",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Connect to WiFi with React Native on Android and iOS.",
   "main": "index.js",
   "types": "index.d.ts",
@@ -23,9 +23,7 @@
     "wifi",
     "iot"
   ],
-  "authors": [
-    "tadasr"
-  ],
+  "author": "tadasr",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/tadasr/react-native-iot-wifi/issues"


### PR DESCRIPTION
This PR adds a podspec and a minor version bump to support newer versions of React Native autolinking. 