### PR TITLE
Podspec to support React Native >= 0.60 and Android compileSDK version bump

### DIFF
--- a/IOTWifi.podspec
+++ b/IOTWifi.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.description         = package['description']
   s.homepage            = package['homepage']
   s.license             = package['license']
-  s.author              = package['author']
+  s.authors             = package['authors']
   s.source              = { :git => 'https://github.com/tadasr/react-native-iot-wifi.git' }
   s.platform              = :ios, '10.3'
   s.ios.deployment_target = '10.3'

--- a/IOTWifi.podspec
+++ b/IOTWifi.podspec
@@ -1,0 +1,21 @@
+require 'json'
+
+package = JSON.parse(File.read('package.json'))
+
+Pod::Spec.new do |s|
+  s.name                = 'IOTWifi'
+  s.version             = package['version']
+  s.summary             = package['description']
+  s.description         = package['description']
+  s.homepage            = package['homepage']
+  s.license             = package['license']
+  s.author              = package['author']
+  s.source              = { :git => 'https://github.com/tadasr/react-native-iot-wifi.git' }
+  s.platform              = :ios, '10.3'
+  s.ios.deployment_target = '10.3'
+  s.source_files        = 'ios/**/*.{h,m}'
+  s.exclude_files       = 'android/**/*'
+  s.exclude_files       = 'example/**/*'
+  s.dependency 'React'
+end 
+

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 Wifi configuration.
 This library was written to config iot devices. With iOS 11 Apple introduced NEHotspotConfiguration class for wifi configuration. Library supports same functionality on ios and android.
 
+## 1.0.1
+* Add a podspec to support autolinking in React Native versions >= 0.60
+
 ## 1.0.0
 * Optional Force binding to a Wifi on both iOS and Android platforms
 * Android: Better error handling

--- a/README.md
+++ b/README.md
@@ -3,7 +3,11 @@ Wifi configuration.
 This library was written to config iot devices. With iOS 11 Apple introduced NEHotspotConfiguration class for wifi configuration. Library supports same functionality on ios and android.
 
 ## 1.0.1
+iOS:
 * Add a podspec to support autolinking in React Native versions >= 0.60
+
+Android: 
+* Update compileSdkVersion to 28
 
 ## 1.0.0
 * Optional Force binding to a Wifi on both iOS and Android platforms

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion 28
     buildToolsVersion '28.0.3'
 
     defaultConfig {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-iot-wifi",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Connect to WiFi with React Native on Android and iOS.",
   "main": "index.js",
   "types": "index.d.ts",
@@ -23,9 +23,7 @@
     "wifi",
     "iot"
   ],
-  "authors": [
-    "tadasr"
-  ],
+  "author": "tadasr",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/tadasr/react-native-iot-wifi/issues"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "wifi",
     "iot"
   ],
-  "author": "tadasr",
+  "authors": [
+    "tadasr"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/tadasr/react-native-iot-wifi/issues"


### PR DESCRIPTION
This PR adds a podspec file to support auto linking in the latest versions of React Native and bumps the Android sdk version to the recommended 28.  

Testing has been done on both Android and iOS platforms on various devices with no issues arising. 